### PR TITLE
Build Linux on metal instead of in docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,11 @@ matrix:
         - ELECTRON_BUILDER_CACHE=$HOME/.cache/electron-builder
 
     - os: linux
-      services: docker
-      language: generic
-
-before_cache:
-  - rm -rf $HOME/.cache/electron-builder/wine
+      language: node_js
+      node_js: "8"
+      env:
+        - ELECTRON_CACHE=$HOME/.cache/electron
+        - ELECTRON_BUILDER_CACHE=$HOME/.cache/electron-builder
 
 cache:
   directories:
@@ -39,18 +39,7 @@ before_script:
 
 script:
   - echo -e "$(curl --silent https://raw.githubusercontent.com/FantasticFiasco/logo/master/logo.ansi)"
-  - |
-    if [ "$TRAVIS_OS_NAME" == "linux" ]; then
-      docker run --rm \
-        --env-file <(env | grep -iE 'DEBUG|NODE_|ELECTRON_|YARN_|NPM_|CI|CIRCLE|TRAVIS|APPVEYOR_|CSC_|_TOKEN|_KEY|AWS_|STRIP|BUILD_') \
-        -v ${PWD}:/project \
-        -v ~/.cache/electron:/root/.cache/electron \
-        -v ~/.cache/electron-builder:/root/.cache/electron-builder \
-        electronuserland/builder:wine \
-        /bin/bash -c "yarn --link-duplicates --pure-lockfile && yarn lint && yarn dist --linux --win"
-    else
-      yarn lint && yarn dist
-    fi
+  - yarn lint && yarn dist
 
 after_script:
   - greenkeeper-lockfile-upload

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,14 @@ matrix:
     - os: osx
       osx_image: xcode9.4
       language: node_js
-      node_js: "8"
+      node_js: 8
       env:
         - ELECTRON_CACHE=$HOME/.cache/electron
         - ELECTRON_BUILDER_CACHE=$HOME/.cache/electron-builder
 
     - os: linux
       language: node_js
-      node_js: "8"
+      node_js: 8
       env:
         - ELECTRON_CACHE=$HOME/.cache/electron
         - ELECTRON_BUILDER_CACHE=$HOME/.cache/electron-builder
@@ -39,7 +39,8 @@ before_script:
 
 script:
   - echo -e "$(curl --silent https://raw.githubusercontent.com/FantasticFiasco/logo/master/logo.ansi)"
-  - yarn lint && yarn dist
+  - yarn lint
+  - yarn dist
 
 after_script:
   - greenkeeper-lockfile-upload

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,3 +44,4 @@ script:
 
 after_script:
   - greenkeeper-lockfile-upload
+

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,6 +21,9 @@ init:
   - git config --global core.autocrlf input
 
 install:
+  - ps: |
+      $logo = (Invoke-WebRequest "https://raw.githubusercontent.com/FantasticFiasco/logo/master/logo.raw").toString();
+      Write-Host "$logo" -ForegroundColor Green
   - ps: Install-Product node $env:NODE_JS x64
   - yarn
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ platform:
   - x64
 
 environment:
-  NODE_JS: 6
+  NODE_JS: 8
   ELECTRON_CACHE: '%USERPROFILE%\.electron'
   ELECTRON_BUILDER_CACHE: '%USERPROFILE%\.electron-builder'
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,10 @@ environment:
   NODE_JS: 8
   ELECTRON_CACHE: '%USERPROFILE%\.electron'
   ELECTRON_BUILDER_CACHE: '%USERPROFILE%\.electron-builder'
+  GH_TOKEN:
+    secure: de2wnJZf6k7NY0XriDpf9BkrQ4MR5ZfDDWMM+H/K4OK3w0GpuJAMRj5PrO6tKu0K
+  UNIVERSAL_ANALYTICS_TRACKING_ID:
+    secure: WH6qEKzg9o2K7l9DVLOyrA==
 
 cache:
   - node_modules

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,13 +5,13 @@ platform:
 
 environment:
   NODE_JS: 6
-  ELECTRON_CACHE: %USERPROFILE%\.electron
-  ELECTRON_BUILDER_CACHE: %USERPROFILE%\.electron-builder
+  ELECTRON_CACHE: '%USERPROFILE%\.electron'
+  ELECTRON_BUILDER_CACHE: '%USERPROFILE%\.electron-builder'
 
 cache:
   - node_modules
-  - %USERPROFILE%\.electron
-  - %USERPROFILE%\.electron-builder
+  - '%USERPROFILE%\.electron'
+  - '%USERPROFILE%\.electron-builder'
 
 branches:
   except:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,24 @@
+image: Visual Studio 2017
+
+platform:
+  - x64
+
+environment:
+  NODE_JS: 6
+
+branches:
+  except:
+    - gh-pages
+
+init:
+  - git config --global core.autocrlf input
+
+install:
+  - ps: Install-Product node $env:NODE_JS x64
+  - yarn
+
+build_script:
+  - yarn lint
+  - yarn dist
+
+test: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,13 @@ platform:
 
 environment:
   NODE_JS: 6
+  ELECTRON_CACHE: %USERPROFILE%\.electron
+  ELECTRON_BUILDER_CACHE: %USERPROFILE%\.electron-builder
+
+cache:
+  - node_modules
+  - %USERPROFILE%\.electron
+  - %USERPROFILE%\.electron-builder
 
 branches:
   except:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,3 +36,6 @@ build_script:
   - yarn dist
 
 test: off
+
+artifacts:
+  - path: dist\**


### PR DESCRIPTION
To prevent problems with NodeJS v10 and dependencies not supporting it, lets control the environment and build on metal instead of in Docker.